### PR TITLE
Fixed typo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,6 @@ RUN chmod -R og+rwx /notebooks
 # We just add a little wrapper script.
 COPY run_jupyter.sh /
 
-WORKDIR /notebooks"
+WORKDIR /notebooks
 
 ENTRYPOINT "/run_jupyter.sh"


### PR DESCRIPTION
Avoid errors when changing workdir during build process:

Step 17/21 : COPY run_jupyter.sh /
 ---> Using cache
 ---> cdced7c4789d
error: build error: failed to process "/notebooks\"": unexpected end of statement while looking for matching double-quote
